### PR TITLE
gzip compress discovery files

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -1,2 +1,4 @@
 #!/bin/sh
 php bin/generate.php
+rm out/*.gz
+gzip -9k out/server_list.json out/organization_list.json


### PR DESCRIPTION
This allows the webserver to handle requests with `Accept-Encoding: gzip` to serve the .gz file instead, with an `Content-Encoding: gzip` header. This allows supporting clients to use less data. Nothing changes for non-supporting clients.

* organization_list.json: 143K -> 21K
* server_list.json: 11K -> 2.6K

The `?: null` part is so that Psalm and Phan complain less, since the result is `?string` instead of `false|string`.

It is not necessary to update signing, since the payload stays the same; `Content-Encoding: gzip` means that the HTTP client must decompress before doing anything with the data, including verifying the signature. We might compress the signatures, but that doesn't seem so useful; signatures are only 300 bytes.