### PR TITLE
Remove "eduVPN for" for Norwegian institutions

### DIFF
--- a/institute_access.json
+++ b/institute_access.json
@@ -66,7 +66,7 @@
         {
             "base_uri": "https://khio.eduvpn.no/",
             "display_name": {
-                "nb": "eduVPN for Kunsth\u00f8gskolen"
+                "nb": "Kunsth\u00f8gskolen"
             },
             "logo": "https://static.eduvpn.nl/disco/img/khio.png",
             "support_contact": [
@@ -76,7 +76,7 @@
         {
             "base_uri": "https://samas.eduvpn.no/",
             "display_name": {
-                "nb": "eduVPN for S\u00e1mi allaskuvla"
+                "nb": "S\u00e1mi allaskuvla"
             },
             "logo": "https://static.eduvpn.nl/disco/img/khio.png",
             "support_contact": [


### PR DESCRIPTION
The "eduVPN string" is needed in the SAML IdP, but not in this JSON